### PR TITLE
Add file import feature

### DIFF
--- a/navigation/AppNavigator.tsx
+++ b/navigation/AppNavigator.tsx
@@ -4,6 +4,7 @@ import { createNativeStackNavigator } from '@react-navigation/native-stack';
 
 import AddRecipe from '../screens/AddRecipe';
 import AddRecipeUrl from '../screens/AddRecipeUrl';
+import AddRecipeFile from '../screens/AddRecipeFile';
 import EditRecipe from '../screens/EditRecipe';
 import EditWithAI from '../screens/EditWithAI';
 import RecipeDetail from '../screens/RecipeDetail';
@@ -26,6 +27,7 @@ export default function AppNavigator() {
         <Stack.Screen name="Settings" component={Settings} />
         <Stack.Screen name="AddRecipe" component={AddRecipe} />
         <Stack.Screen name="AddRecipeUrl" component={AddRecipeUrl} />
+        <Stack.Screen name="AddRecipeFile" component={AddRecipeFile} />
         <Stack.Screen name="EditRecipe" component={EditRecipe} />
         <Stack.Screen name="EditWithAI" component={EditWithAI} />
         <Stack.Screen name="RecipeDetail" component={RecipeDetail} />

--- a/screens/AddRecipeFile.tsx
+++ b/screens/AddRecipeFile.tsx
@@ -1,0 +1,198 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import {
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  ScrollView,
+} from 'react-native';
+import { useNavigation } from '@react-navigation/native';
+import DocumentPicker from 'react-native-document-picker';
+import RNFS from 'react-native-fs';
+import RecipeExtractorService from '../services/RecipeExtractorService';
+import RecipeStore from '../store/RecipeStore';
+import { useTheme } from '../hooks/useTheme';
+import Header from '../components/Header';
+import CustomPopup from '../components/CustomPopup';
+import ContentWrapper from '../components/ContentWrapper';
+
+// helper function to check if a file is likely binary by reading a small sample and looking for null bytes
+// this should prevent users from trying to import non-text files which would cause the extractor to fail
+// at the same time we should avoid limiting by file extension
+const isLikelyBinary = async (filePath: string): Promise<boolean> => {
+  try {
+    const sample = await RNFS.read(filePath, 512, 0, 'ascii');
+    return sample.includes('\0');
+  } catch {
+    return false; // if unreadable, the main flow handles the error
+  }
+};
+
+export default function AddRecipeFile() {
+  const navigation = useNavigation();
+  const [loading, setLoading] = useState(false);
+  const [dots, setDots] = useState('');
+  const { colors } = useTheme();
+  const [showPopup, setShowPopup] = useState(false);
+  const [popupConfig, setPopupConfig] = useState<{
+    title: string;
+    message: string;
+    buttons: Array<{ text: string; onPress: () => void; style?: 'default' | 'cancel' }>;
+  }>({
+    title: '',
+    message: '',
+    buttons: [],
+  });
+
+  const styles = useMemo(() => stylesFactory(colors), [colors]);
+
+  useEffect(() => {
+    let interval: NodeJS.Timeout;
+    if (loading) {
+      interval = setInterval(() => {
+        setDots(prev => {
+          if (prev === '') return '.';
+          if (prev === '.') return '..';
+          if (prev === '..') return '...';
+          return '';
+        });
+      }, 400); // Change dots every 400ms
+    }
+    return () => {
+      if (interval) {
+        clearInterval(interval);
+      }
+      setDots('');
+    };
+  }, [loading]);
+
+  const handleFileImport = async () => {
+    try {
+      const res = await DocumentPicker.pick({
+        type: [DocumentPicker.types.allFiles],
+      });
+
+      const file = res[0];
+      const fileName = file.name ?? '';
+
+      // On Android the picker returns a content:// URI; copy to a temp path so RNFS can read it
+      let filePath = file.fileCopyUri ?? file.uri;
+      if (filePath.startsWith('content://')) {
+        const tempPath = `${RNFS.TemporaryDirectoryPath}/sift_import_${Date.now()}.tmp`;
+        await RNFS.copyFile(filePath, tempPath);
+        filePath = tempPath;
+      }
+
+      if (await isLikelyBinary(filePath)) {
+        setPopupConfig({
+          title: 'Unsupported File',
+          message: 'Please select a text-based file such as .txt, .html, or .md.',
+          buttons: [{ text: 'OK', onPress: () => setShowPopup(false) }],
+        });
+        setShowPopup(true);
+        return;
+      }
+
+      setLoading(true);
+
+      const recipe = await RecipeExtractorService.extractRecipeFromFile(filePath, fileName);
+      await RecipeStore.addRecipe(recipe);
+      navigation.goBack();
+    } catch (error) {
+      if (DocumentPicker.isCancel(error)) return;
+      console.error('File import error:', error);
+      setPopupConfig({
+        title: 'Error',
+        message: 'Failed to extract recipe from file. Please try again.',
+        buttons: [{ text: 'OK', onPress: () => setShowPopup(false) }],
+      });
+      setShowPopup(true);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <View style={styles.flexView}>
+      <Header title="Add recipe" />
+      <ScrollView
+        style={styles.flexView}
+        contentContainerStyle={styles.flexGrow}
+      >
+        <ContentWrapper>
+          <View style={styles.container}>
+            <Text style={styles.hint}>
+              Usage example: Save a recipe page with your browser's "Save Page" feature, then import it here. Useful for paywalled or bot-protected pages.
+            </Text>
+            <TouchableOpacity
+              style={styles.button}
+              onPress={handleFileImport}
+              disabled={loading}
+            >
+              {loading ? (
+                <View style={styles.loadingContainer}>
+                  <Text style={styles.buttonText}>
+                    Adding
+                  </Text>
+                  <Text style={[styles.buttonText, styles.dotsContainer]}>
+                    {dots}
+                  </Text>
+                </View>
+              ) : (
+                <Text style={styles.buttonText}>
+                  Select file
+                </Text>
+              )}
+            </TouchableOpacity>
+          </View>
+        </ContentWrapper>
+      </ScrollView>
+      <CustomPopup
+        visible={showPopup}
+        title={popupConfig.title}
+        message={popupConfig.message}
+        buttons={popupConfig.buttons}
+        onClose={() => setShowPopup(false)}
+      />
+    </View>
+  );
+}
+
+const stylesFactory = (colors: any) => StyleSheet.create({
+  flexView: {
+    flex: 1,
+    backgroundColor: colors.background,
+  },
+  flexGrow: {
+    flexGrow: 1,
+  },
+  container: {
+    flex: 1,
+    padding: 16,
+    backgroundColor: 'transparent',
+  },
+  hint: {
+    fontSize: 13,
+    lineHeight: 19,
+    opacity: 0.5,
+    color: colors.text,
+    marginBottom: 24,
+  },
+  button: {
+    padding: 16,
+    borderRadius: 8,
+    alignItems: 'center',
+    backgroundColor: colors.tint,
+  },
+  buttonText: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: colors.background,
+  },
+  loadingContainer: {
+    flexDirection: 'row',
+  },
+  dotsContainer: {
+    width: 24, // Fixed width for 3 dots
+  },
+});

--- a/screens/AddRecipeUrl.tsx
+++ b/screens/AddRecipeUrl.tsx
@@ -81,7 +81,7 @@ export default function AddRecipeUrl() {
 
     setLoading(true);
     try {
-      const recipe = await RecipeExtractorService.extractRecipe(url);
+      const recipe = await RecipeExtractorService.extractRecipeFromUrl(url);
       recipe.sourceUrl = url.trim();
       await RecipeStore.addRecipe(recipe);
       navigation.goBack();

--- a/screens/RecipeList.tsx
+++ b/screens/RecipeList.tsx
@@ -51,12 +51,17 @@ export default function RecipeList({ navigation }: { navigation: any }) {
     checkAiSettings();
   }, [recipes]);
 
-  const handleAddWithUrl = () => {
+  const handleAddFromUrl = () => {
     setIsMenuVisible(false);
     navigation.navigate('AddRecipeUrl');
   };
 
-  const handleAddManually = () => {
+  const handleAddFromFile = () => {
+    setIsMenuVisible(false);
+    navigation.navigate('AddRecipeFile');
+  };
+
+  const handleAddFromScratch = () => {
     setIsMenuVisible(false);
     navigation.navigate('AddRecipe');
   };
@@ -162,11 +167,14 @@ export default function RecipeList({ navigation }: { navigation: any }) {
               bottom: 90,
               right: 20 
             }]}>
-              <TouchableOpacity style={styles.menuItem} onPress={handleAddWithUrl}>
-                <Text style={styles.menuText}>Add recipe from website</Text>
+              <TouchableOpacity style={styles.menuItem} onPress={handleAddFromUrl}>
+                <Text style={styles.menuText}>Add from website</Text>
               </TouchableOpacity>
-              <TouchableOpacity style={styles.menuItem} onPress={handleAddManually}>
-                <Text style={styles.menuText}>Add recipe manually</Text>
+              <TouchableOpacity style={styles.menuItem} onPress={handleAddFromFile}>
+                <Text style={styles.menuText}>Add from file</Text>
+              </TouchableOpacity>
+              <TouchableOpacity style={styles.menuItem} onPress={handleAddFromScratch}>
+                <Text style={styles.menuText}>Add from scratch</Text>
               </TouchableOpacity>
             </View>
           </TouchableOpacity>

--- a/services/RecipeExtractorService.ts
+++ b/services/RecipeExtractorService.ts
@@ -47,7 +47,6 @@ class RecipeExtractorService {
     }
   }
 
-
   async modifyRecipe(recipe: Recipe, userPrompt: string): Promise<Recipe> {
     await this.loadCustomModelConfig();
 
@@ -111,27 +110,78 @@ class RecipeExtractorService {
     return modified;
   }
 
-  async extractRecipe(url: string, extraInstructions?: string): Promise<Recipe> {
+  // Public method for url-based import.
+  // Fetches the URL, extracts an image, cleans the content,
+  // then delegates to extractRecipe for the actual GPT extraction logic.
+  async extractRecipeFromUrl(url: string, extraInstructions?: string): Promise<Recipe> {
+    try{
+      await this.loadCustomModelConfig();
+      const fetchUrl = Platform.OS === 'web' ? this.corsProxy + url : url;
+      const headers: HeadersInit = Platform.OS === 'web'
+        ? { 'Origin': (window?.location?.origin || 'https://localhost') }
+        : { 'User-Agent': 'Mozilla/5.0' };
+      const response = await fetch(fetchUrl, { headers });
+      const html = await response.text();
+
+      const imageUrl = this.extractFirstImage(html, url);
+      const localImageUri = imageUrl ? await this.downloadAndSaveImage(imageUrl) : null;
+      const cleanContent = this.cleanWebPageContent(html);
+
+      return this.extractRecipe(cleanContent, localImageUri, url, extraInstructions);
+    } catch (error) {
+      console.log('Error extracting recipe:', error);
+      throw error;
+    }
+  }
+
+  // Public method for file-based import.
+  // Reads the file, if HTML file extracts an image and cleans the content, 
+  // then delegates to extractRecipe for the actual GPT extraction logic.
+  async extractRecipeFromFile(
+    filePath: string,
+    fileName: string,
+    extraInstructions?: string
+  ): Promise<Recipe> {
     await this.loadCustomModelConfig();
+    try {
+      // Determine if it's an HTML file based on extension
+      const isHtml = /\.html?$/i.test(fileName);
+      console.log('Reading file:', filePath, '| isHtml:', isHtml);
+      
+      // Read file content
+      const raw = await RNFS.readFile(filePath, 'utf8');
+      console.log('File content length:', raw.length);
+      // If it's HTML, try to extract an image and clean the content
+      const imageUrl = isHtml ? this.extractFirstImage(raw, 'file://') : null;
+      const localImageUri = imageUrl ? await this.downloadAndSaveImage(imageUrl) : null;
+      const cleanContent = isHtml ? this.cleanWebPageContent(raw) : raw.slice(0, 20000);
+      
+      // Delegate to the same extraction logic as URL flow,
+      // passing the cleaned content and local image URI
+      return this.extractRecipe(cleanContent, localImageUri, undefined, extraInstructions);
+    } catch (error) {
+      console.log('Error loading file:', error);
+      throw error;
+    }
+  }
 
-    const fetchUrl = Platform.OS === 'web' ? this.corsProxy + url : url;
-    const headers: HeadersInit = Platform.OS === 'web'
-      ? { 'Origin': (window?.location?.origin || 'https://localhost') }
-      : { 'User-Agent': 'Mozilla/5.0' };
-
-    const response = await fetch(fetchUrl, { headers });
-    const html = await response.text();
-
-    const imageUrl = this.extractFirstImage(html, url);
-    const localImageUri = imageUrl ? await this.downloadAndSaveImage(imageUrl) : null;
-    const cleanContent = this.cleanWebPageContent(html);
-
+  // Private method — owns the AI prompt + parse pipeline.
+  // Called by both extractRecipeFromUrl (URL flow) and extractRecipeFromFile (file flow).
+  // Error handling is done in the public methods
+  private async extractRecipe(
+    cleanContent: string,
+    localImageUri: string | null,
+    sourceUrl?: string,
+    extraInstructions?: string
+  ): Promise<Recipe> {
+      // Prepare GPT prompt for groups schema (v2)
+      // TODO: implement extraInstructions (as advanced model settings?)
     const prompt = `
-        Extract recipe information from the following content.
-        Your primary rule is to ONLY extract information that is explicitly present in the text.
-        Do not invent, assume, translate, or generate any information.
-        If a value for a field is not found, it should be an empty string "" or an empty array [] for lists.
-        Respond ONLY with a valid JSON object matching this schema exactly.
+      Extract recipe information from the following content.
+      Your primary rule is to ONLY extract information that is explicitly present in the text.
+      Do not invent, assume, translate, or generate any information.
+      If a value for a field is not found, it should be an empty string "" or an empty array [] for lists.
+      Respond ONLY with a valid JSON object matching this schema exactly.
 
         {
           "schemaVersion": 2,
@@ -165,12 +215,15 @@ class RecipeExtractorService {
         - Servings: Extract from content. If missing, use an empty string "". DO NOT estimate.
         - Grouping: If the recipe has distinct sections with titles (like "Sauce" or "Dough"), create corresponding groups. If there are no such sections, create just one group for ingredients and one for instructions, leaving the 'title' as an empty string. DO NOT make up your own group titles. DO NOT use generic titles like "Ingredients" or "Instructions."
 
-        Content:
-        ${cleanContent}
-      `;
+      Content:
+      ${cleanContent}
+    `;
 
+    // Call API
     const gptResponse = await this.callGPTAPI(prompt);
-    return this.parseGPTResponse(gptResponse, localImageUri, url);
+    
+    // Parse and create recipe with local image
+    return this.parseGPTResponse(gptResponse, localImageUri, sourceUrl);
   }
 
   private cleanWebPageContent(html: string): string {


### PR DESCRIPTION
**Description:**

Closes #9

Adds the ability to import a recipe from a local file, as an alternative to URL import for paywalled or bot-protected pages.

**Changes:**

- `screens/AddRecipeFile.tsx`: new screen with file picker and binary file detection based on `screens/AddRecipeUrl.tsx`
- `screens/RecipeList.tsx`: added "Add from file" menu item and handler; renamed existing items to "Add from website" and "Add from scratch" as agreed.
- `navigation/AppNavigator.tsx`: registered `AddRecipeFile` screen
- `services/RecipeExtractorService.ts`: refactored to separate the AI pipeline into a private `extractRecipe` method; added public `extractRecipeFromFile`; renamed previous `extractRecipe` to `extractRecipeFromUrl` for clarity and consistency.
- `screens/AddRecipeUrl.tsx`: updated service call to match renamed method

**Notes:**
- Supports any text-based file; binary files are detected via null byte check and rejected before the AI is called
- HTML files are treated as websites and therefore benefit from image extraction if available.
- Tested with HTML and TXT-files.
- Branch has been rebased on current `main`.