### PR TITLE
Feature/share menu

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "sift-recipe-keeper",
-  "version": "1.0.0",
+  "version": "1.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "sift-recipe-keeper",
-      "version": "1.0.0",
+      "version": "1.0.4",
       "dependencies": {
         "@react-native-async-storage/async-storage": "1.23.1",
+        "@react-native-clipboard/clipboard": "^1.16.3",
         "@react-native-community/netinfo": "^11.4.1",
         "@react-navigation/bottom-tabs": "^6.5.11",
         "@react-navigation/native": "^6.1.9",
@@ -2515,6 +2516,29 @@
       },
       "peerDependencies": {
         "react-native": "^0.0.0-0 || >=0.60 <1.0"
+      }
+    },
+    "node_modules/@react-native-clipboard/clipboard": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/@react-native-clipboard/clipboard/-/clipboard-1.16.3.tgz",
+      "integrity": "sha512-cMIcvoZKIrShzJHEaHbTAp458R9WOv0fB6UyC7Ek4Qk561Ow/DrzmmJmH/rAZg21Z6ixJ4YSdFDC14crqIBmCQ==",
+      "license": "MIT",
+      "workspaces": [
+        "example"
+      ],
+      "peerDependencies": {
+        "react": ">= 16.9.0",
+        "react-native": ">= 0.61.5",
+        "react-native-macos": ">= 0.61.0",
+        "react-native-windows": ">= 0.61.0"
+      },
+      "peerDependenciesMeta": {
+        "react-native-macos": {
+          "optional": true
+        },
+        "react-native-windows": {
+          "optional": true
+        }
       }
     },
     "node_modules/@react-native-community/cli": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   },
   "dependencies": {
     "@react-native-async-storage/async-storage": "1.23.1",
+    "@react-native-clipboard/clipboard": "^1.16.3",
     "@react-native-community/netinfo": "^11.4.1",
     "@react-navigation/bottom-tabs": "^6.5.11",
     "@react-navigation/native": "^6.1.9",

--- a/screens/RecipeDetail.tsx
+++ b/screens/RecipeDetail.tsx
@@ -11,10 +11,19 @@ import {
   Modal,
   Pressable,
   Linking,
-  Clipboard,
+  // 'Clipboard' is deprecated.ts(6385)
+  // Clipboard has been extracted from react-native core and
+  // will be removed in a future release. 
+  // It can now be installed and imported from 
+  // @react-native-clipboard/clipboard instead of 'react-native'.
+  //Clipboard, 
   ToastAndroid,
   useWindowDimensions,
+  Share,
 } from 'react-native';
+// see above 
+import Clipboard from '@react-native-clipboard/clipboard';
+
 import { useNavigation, useRoute } from '@react-navigation/native';
 import Ionicons from 'react-native-vector-icons/Ionicons';
 import RecipeStore from '../store/RecipeStore';
@@ -23,6 +32,9 @@ import { useTheme } from '../hooks/useTheme';
 import Header from '../components/Header';
 import CustomPopup from '../components/CustomPopup';
 import ContentWrapper from '../components/ContentWrapper';
+import RNFS from 'react-native-fs';
+import RNShare from 'react-native-share';
+import { buildRecipeZip } from '../services/RecipeExportUtils';
 
 export default function RecipeDetail() {
   const navigation = useNavigation<any>();
@@ -38,6 +50,41 @@ export default function RecipeDetail() {
     return foundRecipe;
   });
   const [isMenuVisible, setIsMenuVisible] = useState(false);
+
+  const [isShareMenuVisible, setIsShareMenuVisible] = useState(false);
+
+  const handleShareUrl = () => {
+    setIsShareMenuVisible(false);
+    Share.share({
+      url: recipe.sourceUrl!,   // iOS
+      message: recipe.sourceUrl!, // Android fallback
+    });
+  };
+
+  const handleShareRecipeText = () => {
+    setIsShareMenuVisible(false);
+    Share.share({ message: formatRecipeForSharing(recipe!) });
+  };
+
+  const handleShareIngredientsText = () => {
+    setIsShareMenuVisible(false);
+    Share.share({ message: formatIngredientsForSharing(recipe!) });
+  };
+
+  const handleShareExport = async () => {
+    setIsShareMenuVisible(false);
+    try {
+      const zipPath = await buildRecipeZip([recipe!]);
+      await RNShare.open({
+        url: `file://${zipPath}`,
+        type: 'application/zip',
+      });
+      RNFS.unlink(zipPath).catch(() => {});
+    } catch (err) {
+      console.error('Failed to share recipe file:', err);
+    }
+  };
+
 
   const { colors } = useTheme();
   const { width: windowWidth } = useWindowDimensions();
@@ -118,6 +165,48 @@ export default function RecipeDetail() {
       return next;
     });
   };
+
+  const formatIngredientsForSharing = (recipe: Recipe): string => {
+    const lines: string[] = [recipe.name, ''];
+
+    (recipe.ingredientsGroups || []).forEach(group => {
+      if (group.title) lines.push(group.title.toUpperCase());
+      group.items.forEach(ing => lines.push(`• ${ing.name}`));
+      lines.push('');
+    });
+    return lines.join('\n').trim();
+  };
+
+  const formatRecipeForSharing = (recipe: Recipe): string => {
+    const lines: string[] = [recipe.name, ''];
+
+    (recipe.ingredientsGroups || []).forEach(group => {
+      if (group.title) lines.push(group.title.toUpperCase());
+      group.items.forEach(ing => lines.push(`• ${ing.name}`));
+      lines.push('');
+    });
+
+    (recipe.instructionGroups || []).forEach(group => {
+      if (group.title) lines.push(group.title.toUpperCase());
+      group.items.forEach((step, i) => {
+        lines.push(`${i + 1}. ${step}`);
+        lines.push('');
+      });
+    });
+
+    if (recipe.sourceUrl) lines.push(`Source: ${recipe.sourceUrl}`);
+    return lines.join('\n').trim();
+  };
+
+  const ShareButton = () => (
+    <Pressable
+      onPress={() => setIsShareMenuVisible(true)}
+      style={({ pressed }) => ({ padding: 8, opacity: pressed ? 0.7 : 1 })}
+      hitSlop={{ top: 10, bottom: 10, left: 10, right: 10 }}
+    >
+      <Ionicons name="share-social-outline" size={24} color={colors.tint} />
+    </Pressable>
+  );
 
   const MenuButton = () => (
     <Pressable 
@@ -214,7 +303,12 @@ export default function RecipeDetail() {
     <View style={styles.container}>
       <Header 
         title={recipe.name}
-        rightElement={<MenuButton />}
+        rightElement={
+          <View style={{ flexDirection: 'row', alignItems: 'center' }}>
+            <ShareButton />
+            <MenuButton />
+          </View>
+        }
       />
       <ScrollView 
         style={{ flex: 1 }}
@@ -294,6 +388,42 @@ export default function RecipeDetail() {
           </View>
         </ContentWrapper>
       </ScrollView>
+
+      <Modal
+        transparent
+        visible={isShareMenuVisible}
+        onRequestClose={() => setIsShareMenuVisible(false)}
+        animationType="fade"
+      >
+        <TouchableOpacity
+          style={styles.modalOverlay}
+          activeOpacity={1}
+          onPress={() => setIsShareMenuVisible(false)}
+        >
+          <View style={[styles.menuContainer, { right: 60, top: 80 }]}>
+            {recipe.sourceUrl ? (
+              <TouchableOpacity style={styles.menuItem} onPress={handleShareUrl}>
+                <Text style={styles.menuText}>Source URL</Text>
+              </TouchableOpacity>
+            ) : (
+              <View style={styles.menuItem}>
+                <Text style={[styles.menuText, { opacity: 0.4 }]}>Source URL</Text>
+                <Text style={[styles.menuText, { opacity: 0.4, fontSize: 13 }]}>No source URL saved</Text>
+              </View>
+            )}
+            <TouchableOpacity style={styles.menuItem} onPress={handleShareRecipeText}>
+              <Text style={styles.menuText}>Recipe Text</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.menuItem} onPress={handleShareIngredientsText}>
+              <Text style={styles.menuText}>Ingredients</Text>
+            </TouchableOpacity>
+            <TouchableOpacity style={styles.menuItem} onPress={handleShareExport}>
+              <Text style={styles.menuText}>Sift Recipe File</Text>
+            </TouchableOpacity>
+          </View>
+        </TouchableOpacity>
+      </Modal>
+
       <Modal
         transparent
         visible={isMenuVisible}

--- a/screens/RecipeDetail.tsx
+++ b/screens/RecipeDetail.tsx
@@ -53,35 +53,45 @@ export default function RecipeDetail() {
 
   const [isShareMenuVisible, setIsShareMenuVisible] = useState(false);
 
-  const handleShareUrl = () => {
+  const handleShareRecipeText = async () => {
     setIsShareMenuVisible(false);
-    Share.share({
-      url: recipe.sourceUrl!,   // iOS
-      message: recipe.sourceUrl!, // Android fallback
-    });
+    try {
+      await Share.share({ message: formatRecipeForSharing(recipe!) });
+    } catch (err: any) {
+      if (err?.message && !err.message.includes('cancel') && !err.message.includes('dismiss') && !err.message.includes('did not share')) {
+        console.error('Failed to share recipe text:', err);
+      }
+    }
   };
 
-  const handleShareRecipeText = () => {
+  const handleShareIngredientsText = async () => {
     setIsShareMenuVisible(false);
-    Share.share({ message: formatRecipeForSharing(recipe!) });
-  };
-
-  const handleShareIngredientsText = () => {
-    setIsShareMenuVisible(false);
-    Share.share({ message: formatIngredientsForSharing(recipe!) });
+    try {
+      await Share.share({ message: formatIngredientsForSharing(recipe!) });
+    } catch (err: any) {
+      if (err?.message && !err.message.includes('cancel') && !err.message.includes('dismiss') && !err.message.includes('did not share')) {
+        console.error('Failed to share ingredients text:', err);
+      }
+    }
   };
 
   const handleShareExport = async () => {
     setIsShareMenuVisible(false);
+    let zipPath: string | null = null;
     try {
-      const zipPath = await buildRecipeZip([recipe!]);
+      zipPath = await buildRecipeZip([recipe!]);
       await RNShare.open({
         url: `file://${zipPath}`,
+        // TODO: change type to e.g. 'application/x-sift-recipe' when registering custom MIME type
         type: 'application/zip',
       });
-      RNFS.unlink(zipPath).catch(() => {});
-    } catch (err) {
-      console.error('Failed to share recipe file:', err);
+    } catch (err: any) {
+      // RNShare throws on user cancellation — don't log that as an error
+      if (err?.message && !err.message.includes('cancel') && !err.message.includes('dismiss') && !err.message.includes('did not share')) {
+        console.error('Failed to share recipe file:', err);
+      }
+    } finally {
+      if (zipPath) RNFS.unlink(zipPath).catch(() => {});
     }
   };
 
@@ -167,7 +177,7 @@ export default function RecipeDetail() {
   };
 
   const formatIngredientsForSharing = (recipe: Recipe): string => {
-    const lines: string[] = [recipe.name, ''];
+    const lines: string[] = [recipe.name + ' - Ingredients', ''];
 
     (recipe.ingredientsGroups || []).forEach(group => {
       if (group.title) lines.push(group.title.toUpperCase());
@@ -301,8 +311,8 @@ export default function RecipeDetail() {
 
   return (
     <View style={styles.container}>
-      <Header 
-        title={recipe.name}
+      <Header
+        title={''} 
         rightElement={
           <View style={{ flexDirection: 'row', alignItems: 'center' }}>
             <ShareButton />
@@ -327,6 +337,7 @@ export default function RecipeDetail() {
               </View>
             )}
 
+            <Text style={styles.recipeTitle} numberOfLines={3}>{recipe.name}</Text>
             <View style={styles.content}>
               <View style={styles.detailsContainer}>
                 {recipe.cookingTime && (
@@ -400,25 +411,15 @@ export default function RecipeDetail() {
           activeOpacity={1}
           onPress={() => setIsShareMenuVisible(false)}
         >
-          <View style={[styles.menuContainer, { right: 60, top: 80 }]}>
-            {recipe.sourceUrl ? (
-              <TouchableOpacity style={styles.menuItem} onPress={handleShareUrl}>
-                <Text style={styles.menuText}>Source URL</Text>
-              </TouchableOpacity>
-            ) : (
-              <View style={styles.menuItem}>
-                <Text style={[styles.menuText, { opacity: 0.4 }]}>Source URL</Text>
-                <Text style={[styles.menuText, { opacity: 0.4, fontSize: 13 }]}>No source URL saved</Text>
-              </View>
-            )}
-            <TouchableOpacity style={styles.menuItem} onPress={handleShareRecipeText}>
-              <Text style={styles.menuText}>Recipe Text</Text>
-            </TouchableOpacity>
+          <View style={[styles.menuContainer, { right: 20, top: 80 }]}>
             <TouchableOpacity style={styles.menuItem} onPress={handleShareIngredientsText}>
               <Text style={styles.menuText}>Ingredients</Text>
             </TouchableOpacity>
+            <TouchableOpacity style={styles.menuItem} onPress={handleShareRecipeText}>
+              <Text style={styles.menuText}>Recipe as text</Text>
+            </TouchableOpacity>
             <TouchableOpacity style={styles.menuItem} onPress={handleShareExport}>
-              <Text style={styles.menuText}>Sift Recipe File</Text>
+              <Text style={styles.menuText}>Recipe as .sift file</Text>
             </TouchableOpacity>
           </View>
         </TouchableOpacity>
@@ -495,6 +496,15 @@ const stylesFactory = (colors: any) => StyleSheet.create({
   sectionHeaderRow: {
     marginTop: 24,
   },
+    recipeTitle: {
+    fontSize: 24,
+    fontWeight: 'bold',
+    opacity: 0.7,
+    color: colors.text,
+    paddingHorizontal: 16,
+    paddingTop: 16,
+    paddingBottom: 4,
+},
   sectionTitle: {
     fontSize: 22,
     fontWeight: 'bold',

--- a/screens/RecipeDetail.tsx
+++ b/screens/RecipeDetail.tsx
@@ -190,6 +190,16 @@ export default function RecipeDetail() {
   const formatRecipeForSharing = (recipe: Recipe): string => {
     const lines: string[] = [recipe.name, ''];
 
+    // Add recipe details
+    const details: string[] = [];
+    if (recipe.cookingTime) details.push(`Cooking time: ${recipe.cookingTime}`);
+    if (recipe.servings) details.push(`Servings: ${recipe.servings}`);
+    if (recipe.calories) details.push(`Calories: ${recipe.calories}`);
+    if (details.length > 0) {
+      lines.push(details.join(' | '));
+      lines.push('');
+    }
+
     (recipe.ingredientsGroups || []).forEach(group => {
       if (group.title) lines.push(group.title.toUpperCase());
       group.items.forEach(ing => lines.push(`• ${ing.name}`));

--- a/screens/settings/ExportRecipes.tsx
+++ b/screens/settings/ExportRecipes.tsx
@@ -68,8 +68,9 @@ export default function ExportRecipes() {
       const zipPath = await buildRecipeZip(recipesToExport);
 
       if (Platform.OS === 'android') {
-          const downloadPath = `${RNFS.DownloadDirectoryPath}/sift-recipes-${Date.now()}.zip`;
-          await RNFS.moveFile(zipPath, downloadPath);
+        const fileName = zipPath.split('/').pop();
+        const downloadPath = `${RNFS.DownloadDirectoryPath}/${fileName}`;
+        await RNFS.moveFile(zipPath, downloadPath);
       } else {
         await Share.share({ url: `file://${zipPath}` });
         RNFS.unlink(zipPath).catch(() => {});

--- a/screens/settings/ExportRecipes.tsx
+++ b/screens/settings/ExportRecipes.tsx
@@ -10,6 +10,7 @@ import Header from '../../components/Header';
 import ContentWrapper from '../../components/ContentWrapper';
 import CustomPopup from '../../components/CustomPopup';
 import { Recipe } from '../../models/Recipe';
+import { buildRecipeZip } from '../../services/RecipeExportUtils';
 
 const SELECT_ALL_ID = 'select-all';
 
@@ -63,66 +64,24 @@ export default function ExportRecipes() {
     }
 
     try {
-      const tempDir = RNFS.TemporaryDirectoryPath + '/sift-export';
-      const tempImagesDir = tempDir + '/images';
-      const zipPath = RNFS.TemporaryDirectoryPath + '/recipes-export.zip';
-      
-      if (await RNFS.exists(tempDir)) {
-        await RNFS.unlink(tempDir);
-      }
-      await RNFS.mkdir(tempDir);
-      await RNFS.mkdir(tempImagesDir);
-
       const recipesToExport = recipes.filter(r => selectedRecipes.includes(r.id));
-      
-      const exportRecipes = await Promise.all(recipesToExport.map(async (recipe: Recipe) => {
-        const recipeData = { ...recipe };
-        
-        if (recipe.imageUri && await RNFS.exists(recipe.imageUri)) {
-          const fileName = recipe.imageUri.split('/').pop() || '';
-          const newImagePath = tempImagesDir + '/' + fileName;
-          
-          try {
-            await RNFS.copyFile(recipe.imageUri, newImagePath);
-            recipeData.imageUri = 'images/' + fileName;
-          } catch (error) {
-            console.error('Error copying image:', error);
-            recipeData.imageUri = '';
-          }
-        } else if (recipe.imageUri) {
-          recipeData.imageUri = '';
-        }
-        
-        return recipeData;
-      }));
-
-      const jsonPath = tempDir + '/recipes.json';
-      await RNFS.writeFile(
-        jsonPath,
-        JSON.stringify(exportRecipes, null, 2)
-      );
-
-      await zip(tempDir, zipPath);
+      const zipPath = await buildRecipeZip(recipesToExport);
 
       if (Platform.OS === 'android') {
-        try {
           const downloadPath = `${RNFS.DownloadDirectoryPath}/sift-recipes-${Date.now()}.zip`;
           await RNFS.moveFile(zipPath, downloadPath);
-          setPopupConfig({
-            title: 'Export Successful',
-            message: 'Your recipes have been saved to the Downloads folder.',
-            buttons: [{ text: 'OK', onPress: () => setShowPopup(false) }],
-          });
-        } catch (err) {
-          console.warn(err);
-          throw err;
-        }
       } else {
         await Share.share({ url: `file://${zipPath}` });
+        RNFS.unlink(zipPath).catch(() => {});
       }
 
-      await RNFS.unlink(tempDir);
-
+      setPopupConfig({
+        title: 'Export Successful',
+        message: Platform.OS === 'android'
+          ? 'Your recipes have been saved to the Downloads folder.'
+          : 'Your recipes have been shared successfully.',
+        buttons: [{ text: 'OK', onPress: () => setShowPopup(false) }],
+      });
     } catch (error) {
       console.error('Export error:', error);
       setPopupConfig({

--- a/screens/settings/ImportExport.tsx
+++ b/screens/settings/ImportExport.tsx
@@ -48,11 +48,28 @@ export default function ImportExport() {
 
     try {
       const res = await DocumentPicker.pick({
-        type: [DocumentPicker.types.zip],
+        // TODO: replace allFiles with ['application/x-sift-recipe', 'application/zip']
+        // once 'application/x-sift-recipe' is registered in AndroidManifest.xml and Info.plist.
+        // .zip is kept for backward compatibility with older Sift exports.
+        type: [DocumentPicker.types.allFiles],
       });
 
       const sourceUri = res[0]?.fileCopyUri ?? res[0]?.uri;
+      const fileName = res[0]?.name ?? '';
 
+      // TODO: remove this check once custom MIME type is registered,
+      // as the picker will then only show .sift and .zip files.
+      // .zip is kept for backward compatibility with older Sift exports.
+      if (!fileName.endsWith('.zip') && !fileName.endsWith('.sift')) {
+        setPopupConfig({
+          title: 'Invalid File',
+          message: 'Please select a valid Sift export file (.sift or .zip).',
+          buttons: [{ text: 'OK', onPress: () => setShowPopup(false) }],
+        });
+        setShowPopup(true);
+        return;
+      }
+      
       if (sourceUri) {
         const tempDir = RNFS.TemporaryDirectoryPath + '/import/';
         if (await RNFS.exists(tempDir)) {

--- a/services/RecipeExportUtils.ts
+++ b/services/RecipeExportUtils.ts
@@ -1,0 +1,40 @@
+import RNFS from 'react-native-fs';
+import { zip } from 'react-native-zip-archive';
+import { Recipe } from '../models/Recipe';
+
+export async function buildRecipeZip(recipes: Recipe[]): Promise<string> {
+  const timestamp = Date.now();
+  const tempDir = `${RNFS.TemporaryDirectoryPath}/sift-export-${timestamp}`;
+  const tempImagesDir = `${tempDir}/images`;
+const zipFileName = recipes.length === 1 
+    ? `sift-recipe-${recipes[0].name.replace(/\s+/g, '-')}-${timestamp}.zip`
+    : `sift-recipes-${timestamp}.zip`;
+  const zipPath = `${RNFS.TemporaryDirectoryPath}/${zipFileName}`;
+
+  await RNFS.mkdir(tempDir);
+  await RNFS.mkdir(tempImagesDir);
+
+  const exportData = await Promise.all(recipes.map(async (recipe) => {
+    const recipeData: any = { ...recipe };
+
+    if (recipe.imageUri && await RNFS.exists(recipe.imageUri)) {
+      const fileName = recipe.imageUri.split('/').pop() || '';
+      try {
+        await RNFS.copyFile(recipe.imageUri, `${tempImagesDir}/${fileName}`);
+        recipeData.imageUri = `images/${fileName}`;
+      } catch {
+        recipeData.imageUri = '';
+      }
+    } else {
+      recipeData.imageUri = '';
+    }
+
+    return recipeData;
+  }));
+
+  await RNFS.writeFile(`${tempDir}/recipes.json`, JSON.stringify(exportData, null, 2));
+  await zip(tempDir, zipPath);
+  await RNFS.unlink(tempDir);
+
+  return zipPath;
+}

--- a/services/RecipeExportUtils.ts
+++ b/services/RecipeExportUtils.ts
@@ -6,10 +6,32 @@ export async function buildRecipeZip(recipes: Recipe[]): Promise<string> {
   const timestamp = Date.now();
   const tempDir = `${RNFS.TemporaryDirectoryPath}/sift-export-${timestamp}`;
   const tempImagesDir = `${tempDir}/images`;
-const zipFileName = recipes.length === 1 
-    ? `sift-recipe-${recipes[0].name.replace(/\s+/g, '-')}-${timestamp}.zip`
-    : `sift-recipes-${timestamp}.zip`;
-  const zipPath = `${RNFS.TemporaryDirectoryPath}/${zipFileName}`;
+
+
+  // Generate the export filename for the .sift archive.
+  // For a single recipe, use a slugified version of the recipe name.
+  // For multiple recipes, use a generic name with a timestamp.
+  // Filename rules:
+  // - Only lowercase letters, numbers, and hyphens allowed
+  // - Max length of 40 characters (excluding extension)
+  // - If truncation is needed, try to cut at a hyphen for better readability
+  // NOTE: .sift files are standard ZIP archives and can be
+  //       imported by both current and older versions of Sift (as .zip).
+  const toSlug = (name: string, maxLen = 40): string => {
+    const slug = name
+      .toLowerCase()
+      .replace(/[^a-z0-9\s-]/g, '')
+      .trim()
+      .replace(/\s+/g, '-')
+      .replace(/-{2,}/g, '-');
+    if (slug.length <= maxLen) return slug;
+    const truncated = slug.substring(0, maxLen);
+    const lastHyphen = truncated.lastIndexOf('-');
+    return lastHyphen > 10 ? truncated.substring(0, lastHyphen) : truncated;
+  };
+  const zipFileName = recipes.length === 1
+    ? `${toSlug(recipes[0].name)}.sift`
+    : `sift-recipes-${timestamp}.sift`;
 
   await RNFS.mkdir(tempDir);
   await RNFS.mkdir(tempImagesDir);
@@ -31,6 +53,8 @@ const zipFileName = recipes.length === 1
 
     return recipeData;
   }));
+
+  const zipPath = `${RNFS.TemporaryDirectoryPath}/${zipFileName}`;
 
   await RNFS.writeFile(`${tempDir}/recipes.json`, JSON.stringify(exportData, null, 2));
   await zip(tempDir, zipPath);


### PR DESCRIPTION
Closes #17 
closes #16 

## Changes

### `screens/RecipeDetail.tsx`
- Added share button to the header alongside the existing `...` menu
- Added three options: _Ingredients_, _Recipe as text_, _Recipe as .sift file_
- Share menu aligned to the existing `...` menu position, as requested
- Added `formatRecipeForSharing()` and `formatIngredientsForSharing()` helpers
- Migrated deprecated `Clipboard` from `react-native` core to `@react-native-clipboard/clipboard`
- Applied error handling; user share cancellation is silenced
- Moved Recipe title from header to a section below the picture, limited to 3 lines, as requested

### `services/RecipeExportUtils.ts`
- Export files now use `.sift` extension instead of `.zip`
- Single recipe filename: slugified recipe name, max 40 chars, truncated at word boundary (e.g. `chocolate-chip-cookies.sift`)
- Multiple recipe filename: `sift-recipes-<timestamp>.sift`

### `screens/settings/ExportRecipes.tsx`
- Android download path updated to use `.sift` extension
- Filename derived from `buildRecipeZip` in `services/RecipeExportUtils.ts`

### `screens/settings/ImportExport.tsx`
- DocumentPicker updated temporarily to `allFiles` to also support `.sift` during import pending custom MIME type registration for auto-open Sift app on sharing (see roadmap in README)
- Added file extension validation to support only `.zip` and `.sift` (.zip for backward compatibility)
- Added TODO comments suggesting to register `application/x-sift-recipe` as custom MIME type