### PR TITLE
Removed arcee-ai/trinity-large-preview:free from supportedModels.json

### DIFF
--- a/model-tools/supportedModels.json
+++ b/model-tools/supportedModels.json
@@ -27,7 +27,6 @@
       {
         "label": "Free, might be unstable and have rate limits",
         "models": [
-          "arcee-ai/trinity-large-preview:free"
         ]
       }
     ]


### PR DESCRIPTION
Model arcee-ai/trinity-large-preview:free is not available anymore.